### PR TITLE
Apply all 10 fixes from fixes.md

### DIFF
--- a/PD2026_app/app/src/main/kotlin/sk/punkacidetom/pd2026/MainActivity.kt
+++ b/PD2026_app/app/src/main/kotlin/sk/punkacidetom/pd2026/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -42,7 +43,7 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             val isFontLarge by userPrefs.isFontLarge.collectAsState(initial = false)
-            val fontScale = if (isFontLarge) 1.30f else 1.0f
+            val fontScale = if (isFontLarge) 1.40f else 1.12f
 
             // Collect bands for NowPlayingHeader + start-destination decision
             val bands by bandRepository.observeBands().collectAsState(initial = emptyList())
@@ -62,11 +63,13 @@ class MainActivity : ComponentActivity() {
                             sk.punkacidetom.pd2026.navigation.BandDetailRoute(bandId)
                         )
                     },
-                ) { _ ->
+                ) { innerPadding ->
                     AppNavHost(
                         navController = navController,
                         startDestination = startDestination,
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
                     )
                 }
             }

--- a/PD2026_app/app/src/main/kotlin/sk/punkacidetom/pd2026/PD2026App.kt
+++ b/PD2026_app/app/src/main/kotlin/sk/punkacidetom/pd2026/PD2026App.kt
@@ -3,12 +3,35 @@ package sk.punkacidetom.pd2026
 import android.app.Application
 import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.HiltAndroidApp
+import dagger.hilt.EntryPoint
+import dagger.hilt.EntryPoints
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import sk.punkacidetom.pd2026.core.data.repository.UserPreferencesRepository
+import sk.punkacidetom.pd2026.core.i18n.LocaleHelper
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface UserPrefsEntryPoint {
+    fun userPrefsRepository(): UserPreferencesRepository
+}
 
 @HiltAndroidApp
 class PD2026App : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        // Apply the saved locale before any Activity is created so the OS uses
+        // the correct resource qualifiers from the very first frame.
+        // runBlocking is acceptable here: DataStore reads a tiny cached preference.
+        val userPrefs = EntryPoints.get(this, UserPrefsEntryPoint::class.java)
+            .userPrefsRepository()
+        val savedLang = runBlocking { userPrefs.language.first() }  // defaults to "sk"
+        LocaleHelper().applyLocale(savedLang)
+
         // Subscribe to the single broadcast topic (all devices, Slovak-only notifications)
         FirebaseMessaging.getInstance().subscribeToTopic("pd2026_all")
     }

--- a/PD2026_app/app/src/main/kotlin/sk/punkacidetom/pd2026/navigation/AppBottomBar.kt
+++ b/PD2026_app/app/src/main/kotlin/sk/punkacidetom/pd2026/navigation/AppBottomBar.kt
@@ -51,9 +51,8 @@ fun AppBottomBar(navController: NavHostController) {
             isSelected = currentRoute?.contains("HomeRoute") == true,
             onClick = {
                 navController.navigate(HomeRoute) {
-                    popUpTo(navController.graph.startDestinationId) { saveState = true }
+                    popUpTo(0) { inclusive = true }
                     launchSingleTop = true
-                    restoreState = true
                 }
             },
         )

--- a/PD2026_app/app/src/main/res/values/themes.xml
+++ b/PD2026_app/app/src/main/res/values/themes.xml
@@ -3,7 +3,7 @@
     <!-- Base application theme — used only for the splash/launch window. -->
     <!-- All Compose theming is handled by PD2026Theme in core-ui. -->
     <style name="Theme.PD2026" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <item name="android:windowBackground">@color/pd_navy</item>
+        <item name="android:windowBackground">@color/pd_black</item>
         <item name="android:statusBarColor">@color/pd_navy_dark</item>
         <item name="android:navigationBarColor">@color/pd_navy_dark</item>
         <item name="android:windowLightStatusBar">false</item>

--- a/PD2026_app/core/core-model/src/main/kotlin/sk/punkacidetom/pd2026/core/model/Band.kt
+++ b/PD2026_app/core/core-model/src/main/kotlin/sk/punkacidetom/pd2026/core/model/Band.kt
@@ -21,9 +21,14 @@ data class Band(
     fun description(locale: String): String =
         if (locale.startsWith("en") && descriptionEn.isNotBlank()) descriptionEn else description
 
-    val bandImageUrl: String
+    val bandImagePngUrl: String
         get() = if (imageName.isNotBlank())
-            "https://davidbadin.github.io/PD2026_app/pd_resources/bands/$imageName"
+            "https://davidbadin.github.io/PD2026_app/bands/$imageName.png"
+        else ""
+
+    val bandImageJpgUrl: String
+        get() = if (imageName.isNotBlank())
+            "https://davidbadin.github.io/PD2026_app/bands/$imageName.jpg"
         else ""
 
     val spotifyArtistUrl: String

--- a/PD2026_app/core/core-ui/src/main/kotlin/sk/punkacidetom/pd2026/core/ui/icons/FaCodes.kt
+++ b/PD2026_app/core/core-ui/src/main/kotlin/sk/punkacidetom/pd2026/core/ui/icons/FaCodes.kt
@@ -1,43 +1,46 @@
 package sk.punkacidetom.pd2026.core.ui.icons
 
 // Font Awesome 7 Free — Regular weight codepoints
+// NOTE: FA7 Regular Free has a much smaller icon set than FA6.
+// Icons marked "→" have been substituted with the nearest visually available glyph
+// confirmed present in the installed fa_regular_400.otf binary.
 val FaRegularCodes: Map<String, Int> = mapOf(
-    "heart" to 0xF004,
-    "star" to 0xF005,
-    "calendar" to 0xF073,
-    "clock" to 0xF017,
-    "bell" to 0xF0F3,
-    "bookmark" to 0xF02E,
-    "user" to 0xF007,
-    "circle-info" to 0xF05A,
-    "gear" to 0xF013,
-    "music" to 0xF001,
-    "newspaper" to 0xF1EA,
-    "ticket" to 0xF145,
-    "house" to 0xF015,
-    "arrow-left" to 0xF060,
-    "arrow-right" to 0xF061,
+    "heart" to 0xF004,       // ✓ present
+    "star" to 0xF005,        // ✓ present
+    "calendar" to 0xF073,    // ✓ present
+    "clock" to 0xF017,       // ✓ present
+    "bell" to 0xF0F3,        // ✓ present
+    "bookmark" to 0xF02E,    // ✓ present
+    "user" to 0xF007,        // ✓ present
+    "circle-info" to 0xF059, // → circle-question (F05A missing)
+    "gear" to 0xF443,        // → filter icon (F013 missing in FA7 Regular Free)
+    "music" to 0xF025,       // → headphones (F001 missing)
+    "newspaper" to 0xF1EA,   // ✓ present
+    "ticket" to 0xF09D,      // → credit-card (F145 missing)
+    "house" to 0xF015,       // ✓ present
+    "arrow-left" to 0xF190,  // → circle-left (F060 missing)
+    "arrow-right" to 0xF18E, // → circle-right (F061 missing)
     "location-dot" to 0xF3C5,
-    "play" to 0xF04B,
-    "pause" to 0xF04C,
-    "stop" to 0xF04D,
+    "play" to 0xF144,        // → circle-play (F04B missing)
+    "pause" to 0xF28C,       // → circle-pause (F04C missing)
+    "stop" to 0xF28E,        // → circle-stop (F04D missing)
     "magnifying-glass" to 0xF002,
-    "sliders" to 0xF1DE,
-    "chevron-left" to 0xF053,
-    "chevron-right" to 0xF054,
+    "sliders" to 0xF022,     // → pen-to-square (F1DE missing; closest available)
+    "chevron-left" to 0xF150, // → square-caret-left (F053 missing)
+    "chevron-right" to 0xF151, // → square-caret-right (F054 missing)
     "chevron-down" to 0xF078,
     "chevron-up" to 0xF077,
     "rotate" to 0xF021,
-    "share" to 0xF064,
-    "xmark" to 0xF00D,
-    "check" to 0xF00C,
-    "plus" to 0xF067,
+    "share" to 0xF1D8,       // → paper-plane (F064 missing)
+    "xmark" to 0xF057,       // → circle-xmark (F00D missing)
+    "check" to 0xF058,       // → circle-check (F00C missing)
+    "plus" to 0xF0FE,        // → square-plus (F067 missing)
     "bars" to 0xF0C9,
-    "envelope" to 0xF0E0,
+    "envelope" to 0xF0E0,    // ✓ present
     "globe" to 0xF0AC,
     "link" to 0xF0C1,
     "list" to 0xF03A,
-    "circle" to 0xF111,
+    "circle" to 0xF111,      // ✓ present
 )
 
 // Font Awesome 7 Free — Brands weight codepoints

--- a/PD2026_app/core/core-ui/src/main/res/values/colors.xml
+++ b/PD2026_app/core/core-ui/src/main/res/values/colors.xml
@@ -10,4 +10,5 @@
     <color name="pd_white">#FFFFFF</color>
     <color name="pd_white_60">#99FFFFFF</color>
     <color name="pd_white_30">#4DFFFFFF</color>
+    <color name="pd_black">#000000</color>
 </resources>

--- a/PD2026_app/feature/feature-bands/src/main/kotlin/sk/punkacidetom/pd2026/feature/bands/BandDetailScreen.kt
+++ b/PD2026_app/feature/feature-bands/src/main/kotlin/sk/punkacidetom/pd2026/feature/bands/BandDetailScreen.kt
@@ -18,6 +18,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -185,14 +188,23 @@ fun BandDetailScreen(
 @Composable
 private fun BandHeaderImage(band: Band?, modifier: Modifier = Modifier) {
     val spacing = LocalAppSpacing.current
+    // remember must be called unconditionally (Rules of Composables)
+    var usePng by remember(band?.imageName) { mutableStateOf(true) }
+    val imageUrl = when {
+        band == null || band.bandImagePngUrl.isBlank() -> ""
+        usePng -> band.bandImagePngUrl
+        else -> band.bandImageJpgUrl
+    }
+
     Box(modifier = modifier) {
-        if (band != null && band.bandImageUrl.isNotBlank()) {
+        if (imageUrl.isNotBlank()) {
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
-                    .data(band.bandImageUrl)
+                    .data(imageUrl)
+                    .listener(onError = { _, _ -> if (usePng) usePng = false })
                     .crossfade(true)
                     .build(),
-                contentDescription = band.name,
+                contentDescription = band?.name,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize(),
             )

--- a/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
+++ b/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
@@ -38,11 +38,6 @@ import sk.punkacidetom.pd2026.core.ui.theme.Navy
 import sk.punkacidetom.pd2026.core.ui.theme.NavyLight
 import sk.punkacidetom.pd2026.core.ui.theme.White
 import sk.punkacidetom.pd2026.core.ui.theme.WhiteAlpha60
-import sk.punkacidetom.pd2026.feature.spotify.SpotifyPlayerComposable
-import sk.punkacidetom.pd2026.feature.spotify.spotifyPlaylistEmbedUrl
-import sk.punkacidetom.pd2026.feature.spotify.util.SpotifyLauncher
-
-private const val FESTIVAL_PLAYLIST_ID = "5QL8HJ0cWaLGS2Qxby0xDG"
 private const val URL_FACEBOOK = "https://www.facebook.com/punkacidetom"
 private const val URL_INSTAGRAM = "https://www.instagram.com/festival_punkaci_detom/"
 
@@ -119,23 +114,6 @@ fun HomeScreen(
             }
             Spacer(modifier = Modifier.height(spacing.sm))
         }
-
-        Spacer(modifier = Modifier.height(spacing.lg))
-
-        // Spotify playlist
-        Text(
-            text = stringResource(R.string.home_spotify_playlist),
-            style = MaterialTheme.typography.headlineSmall,
-            color = White,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Spacer(modifier = Modifier.height(spacing.sm))
-        SpotifyPlayerComposable(
-            embedUrl = spotifyPlaylistEmbedUrl(FESTIVAL_PLAYLIST_ID),
-            openLabel = stringResource(R.string.home_spotify_open),
-            onOpenClick = { SpotifyLauncher.openPlaylist(context, FESTIVAL_PLAYLIST_ID) },
-            embedHeight = 352,
-        )
 
         Spacer(modifier = Modifier.height(spacing.lg))
 

--- a/PD2026_app/feature/feature-home/src/main/res/values-en/strings.xml
+++ b/PD2026_app/feature/feature-home/src/main/res/values-en/strings.xml
@@ -12,6 +12,4 @@
     <string name="home_countdown_hours">hours</string>
     <string name="home_countdown_minutes">minutes</string>
     <string name="home_countdown_seconds">seconds</string>
-    <string name="home_spotify_playlist">Festival playlist</string>
-    <string name="home_spotify_open">Open in Spotify</string>
 </resources>

--- a/PD2026_app/feature/feature-home/src/main/res/values/strings.xml
+++ b/PD2026_app/feature/feature-home/src/main/res/values/strings.xml
@@ -12,6 +12,4 @@
     <string name="home_countdown_hours">hodín</string>
     <string name="home_countdown_minutes">minút</string>
     <string name="home_countdown_seconds">sekúnd</string>
-    <string name="home_spotify_playlist">Festival playlist</string>
-    <string name="home_spotify_open">Otvoriť v Spotify</string>
 </resources>

--- a/PD2026_app/feature/feature-news/src/main/kotlin/sk/punkacidetom/pd2026/feature/news/NewsScreen.kt
+++ b/PD2026_app/feature/feature-news/src/main/kotlin/sk/punkacidetom/pd2026/feature/news/NewsScreen.kt
@@ -1,84 +1,23 @@
 package sk.punkacidetom.pd2026.feature.news
 
-import android.annotation.SuppressLint
 import android.net.Uri
-import android.webkit.WebView
-import android.webkit.WebViewClient
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.viewinterop.AndroidView
-import sk.punkacidetom.pd2026.core.ui.theme.Crimson
-import sk.punkacidetom.pd2026.core.ui.theme.LocalAppSpacing
-import sk.punkacidetom.pd2026.core.ui.theme.Navy
-import sk.punkacidetom.pd2026.core.ui.theme.White
 
-@SuppressLint("SetJavaScriptEnabled")
+private const val FACEBOOK_URL = "https://www.facebook.com/punkacidetom"
+
 @Composable
 fun NewsScreen(modifier: Modifier = Modifier) {
     val context = LocalContext.current
-    val spacing = LocalAppSpacing.current
 
-    // Choose locale-specific HTML asset
-    val localeTag = context.resources.configuration.locales[0].language
-    val assetFile = if (localeTag.startsWith("en")) "news_en.html" else "news_sk.html"
-
-    val webView = remember {
-        WebView(context).apply {
-            webViewClient = WebViewClient()
-            settings.javaScriptEnabled = true
-            settings.domStorageEnabled = true
-            settings.loadWithOverviewMode = true
-            settings.useWideViewPort = true
-            loadUrl("file:///android_asset/$assetFile")
-        }
-    }
-
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(Navy),
-    ) {
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth(),
-        ) {
-            AndroidView(factory = { webView }, modifier = Modifier.fillMaxSize())
-        }
-
-        // Fallback button shown below the WebView
-        Button(
-            onClick = {
-                CustomTabsIntent.Builder().build()
-                    .launchUrl(context, Uri.parse("https://www.facebook.com/punkacidetom"))
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(spacing.md),
-            colors = ButtonDefaults.buttonColors(containerColor = Crimson),
-        ) {
-            Text(
-                text = stringResource(R.string.news_open_facebook),
-                style = MaterialTheme.typography.labelLarge,
-                color = White,
-            )
-        }
+    // Open Facebook page directly in Chrome Custom Tab on first composition.
+    // No intermediate screen is needed — the Custom Tab provides the full page experience.
+    LaunchedEffect(Unit) {
+        CustomTabsIntent.Builder()
+            .build()
+            .launchUrl(context, Uri.parse(FACEBOOK_URL))
     }
 }

--- a/PD2026_app/feature/feature-spotify/src/main/kotlin/sk/punkacidetom/pd2026/feature/spotify/SpotifyPlayerComposable.kt
+++ b/PD2026_app/feature/feature-spotify/src/main/kotlin/sk/punkacidetom/pd2026/feature/spotify/SpotifyPlayerComposable.kt
@@ -1,6 +1,7 @@
 package sk.punkacidetom.pd2026.feature.spotify
 
 import android.annotation.SuppressLint
+import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.background
@@ -16,9 +17,12 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -34,6 +38,9 @@ import sk.punkacidetom.pd2026.feature.spotify.util.SpotifyLauncher
  * Shows a Spotify iframe embed (WebView) and an "Open in Spotify" button.
  * When the Spotify app is installed, the button deep-links directly into it.
  * When not installed, Chrome Custom Tabs opens the web player.
+ *
+ * The WebView height adapts dynamically to the embedded content height (min 80dp),
+ * so the enclosing Box never wastes space when the compact player is shown.
  */
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -42,24 +49,40 @@ fun SpotifyPlayerComposable(
     openLabel: String = stringResource(sk.punkacidetom.pd2026.feature.spotify.R.string.spotify_open_app),
     onOpenClick: () -> Unit,
     modifier: Modifier = Modifier,
-    embedHeight: Int = 152,
+    embedHeight: Int = 152, // kept for API compatibility; actual height is measured dynamically
 ) {
     val spacing = LocalAppSpacing.current
+    var webHeight by remember { mutableStateOf(80) }
 
     Column(modifier = modifier.fillMaxWidth()) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(embedHeight.dp)
+                .height(webHeight.dp.coerceAtLeast(80.dp))
                 .clip(RoundedCornerShape(spacing.cardCorner))
                 .background(NavyLight),
         ) {
             AndroidView(
                 factory = { ctx ->
                     WebView(ctx).apply {
-                        webViewClient = WebViewClient()
                         settings.javaScriptEnabled = true
                         settings.domStorageEnabled = true
+                        addJavascriptInterface(
+                            object {
+                                @JavascriptInterface
+                                fun reportHeight(h: Int) {
+                                    webHeight = h.coerceAtLeast(80)
+                                }
+                            },
+                            "Android",
+                        )
+                        webViewClient = object : WebViewClient() {
+                            override fun onPageFinished(view: WebView, url: String) {
+                                view.evaluateJavascript(
+                                    "(function() { Android.reportHeight(document.body.scrollHeight); })();",
+                                ) {}
+                            }
+                        }
                         loadUrl(embedUrl)
                     }
                 },

--- a/PD2026_app/feature/feature-timetable/src/main/kotlin/sk/punkacidetom/pd2026/feature/timetable/TimetableScreen.kt
+++ b/PD2026_app/feature/feature-timetable/src/main/kotlin/sk/punkacidetom/pd2026/feature/timetable/TimetableScreen.kt
@@ -3,9 +3,11 @@ package sk.punkacidetom.pd2026.feature.timetable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -26,6 +28,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import sk.punkacidetom.pd2026.core.model.Band
@@ -37,8 +40,13 @@ import sk.punkacidetom.pd2026.core.ui.theme.Navy
 import sk.punkacidetom.pd2026.core.ui.theme.NavyLight
 import sk.punkacidetom.pd2026.core.ui.theme.White
 import sk.punkacidetom.pd2026.core.ui.theme.WhiteAlpha60
+import java.time.Duration
+import java.time.LocalDateTime
 import java.time.format.TextStyle
 import java.util.Locale
+
+/** Height (dp) for each minute on the proportional timeline. */
+private const val MINUTE_HEIGHT_DP = 2f
 
 @Composable
 fun TimetableScreen(
@@ -117,8 +125,9 @@ fun TimetableScreen(
 
         Spacer(modifier = Modifier.height(spacing.xs))
 
-        // Two-column timetable
-        if (uiState.stageABands.isEmpty() && uiState.stageBBands.isEmpty()) {
+        // Two-column proportional timetable
+        val allBands = uiState.stageABands + uiState.stageBBands
+        if (allBands.isEmpty()) {
             Text(
                 text = stringResource(R.string.timetable_no_slots),
                 style = MaterialTheme.typography.bodyMedium,
@@ -126,6 +135,12 @@ fun TimetableScreen(
                 modifier = Modifier.padding(spacing.md),
             )
         } else {
+            // Compute timeline bounds with LocalDateTime to handle midnight crossover
+            val dayStartDt = allBands.minOf { LocalDateTime.of(it.startDate, it.startTime) }
+            val dayEndDt = allBands.maxOf { LocalDateTime.of(it.endDate, it.endTime) }
+            val totalMinutes = Duration.between(dayStartDt, dayEndDt).toMinutes()
+            val totalTimelineHeight = (totalMinutes * MINUTE_HEIGHT_DP).dp
+
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -133,28 +148,73 @@ fun TimetableScreen(
                     .padding(horizontal = spacing.md),
                 verticalAlignment = Alignment.Top,
             ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    uiState.stageABands.forEach { band ->
-                        SlotCard(
-                            band = band,
-                            isFavourite = uiState.favouriteIds.contains(band.id),
-                            onClick = { onBandClick(band.id) },
-                        )
-                        Spacer(modifier = Modifier.height(spacing.sm))
-                    }
-                }
+                ProportionalStageColumn(
+                    bands = uiState.stageABands,
+                    dayStartDt = dayStartDt,
+                    totalTimelineHeight = totalTimelineHeight,
+                    favouriteIds = uiState.favouriteIds,
+                    onBandClick = onBandClick,
+                    modifier = Modifier.weight(1f),
+                )
+
                 Spacer(modifier = Modifier.width(spacing.sm))
-                Column(modifier = Modifier.weight(1f)) {
-                    uiState.stageBBands.forEach { band ->
-                        SlotCard(
-                            band = band,
-                            isFavourite = uiState.favouriteIds.contains(band.id),
-                            onClick = { onBandClick(band.id) },
-                        )
-                        Spacer(modifier = Modifier.height(spacing.sm))
-                    }
-                }
+
+                ProportionalStageColumn(
+                    bands = uiState.stageBBands,
+                    dayStartDt = dayStartDt,
+                    totalTimelineHeight = totalTimelineHeight,
+                    favouriteIds = uiState.favouriteIds,
+                    onBandClick = onBandClick,
+                    modifier = Modifier.weight(1f),
+                )
             }
+        }
+    }
+}
+
+@Composable
+private fun ProportionalStageColumn(
+    bands: List<Band>,
+    dayStartDt: LocalDateTime,
+    totalTimelineHeight: Dp,
+    favouriteIds: Set<Int>,
+    onBandClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Remove overlapping bands within this column (keep earlier ones, skip later ones)
+    val dedupedBands: List<Band> = buildList {
+        var lastEndDt = LocalDateTime.MIN
+        for (band in bands.sortedWith(compareBy({ it.startDate }, { it.startTime }))) {
+            val bandStartDt = LocalDateTime.of(band.startDate, band.startTime)
+            if (bandStartDt >= lastEndDt) {
+                add(band)
+                lastEndDt = LocalDateTime.of(band.endDate, band.endTime)
+            }
+            // else: skip — overlapping entry in the same column
+        }
+    }
+
+    Box(modifier = modifier.height(totalTimelineHeight)) {
+        dedupedBands.forEach { band ->
+            val bandStartDt = LocalDateTime.of(band.startDate, band.startTime)
+            val bandEndDt = LocalDateTime.of(band.endDate, band.endTime)
+
+            val offsetMinutes = Duration.between(dayStartDt, bandStartDt).toMinutes()
+            val durationMinutes = Duration.between(bandStartDt, bandEndDt).toMinutes()
+                .coerceAtLeast(1L)
+
+            val offsetDp = (offsetMinutes * MINUTE_HEIGHT_DP).dp
+            val heightDp = (durationMinutes * MINUTE_HEIGHT_DP).dp
+
+            SlotCard(
+                band = band,
+                isFavourite = favouriteIds.contains(band.id),
+                onClick = { onBandClick(band.id) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .absoluteOffset(y = offsetDp)
+                    .height(heightDp),
+            )
         }
     }
 }
@@ -164,14 +224,14 @@ private fun SlotCard(
     band: Band,
     isFavourite: Boolean,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val spacing = LocalAppSpacing.current
     val timeStr = "${band.startTime.hour}:${band.startTime.minute.toString().padStart(2, '0')}" +
         " – ${band.endTime.hour}:${band.endTime.minute.toString().padStart(2, '0')}"
 
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
+        modifier = modifier
             .clip(RoundedCornerShape(spacing.cardCorner))
             .background(NavyLight)
             .clickable(onClick = onClick)
@@ -213,12 +273,6 @@ private fun SlotCard(
                 overflow = TextOverflow.Ellipsis,
             )
         }
-        Text(
-            text = Stages.displayName(band.stageCode),
-            style = MaterialTheme.typography.labelSmall,
-            color = WhiteAlpha60,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        // Stage name intentionally omitted — shown in the column header above
     }
 }


### PR DESCRIPTION
## Summary

- **#1 Locale**: `PD2026App.onCreate()` now reads saved language via Hilt EntryPoint + `runBlocking { userPrefs.language.first() }` and calls `LocaleHelper().applyLocale()`, ensuring Slovak is used as default on fresh install
- **#2 Timetable**: Replaced `Column + Spacer` layout with proportional `Box + absoluteOffset` timeline (2 dp/min). Stage name removed from `SlotCard` since it's in the column header. Midnight crossover handled via `LocalDateTime`.
- **#3 Icons**: Updated `FaRegularCodes` to substitute missing FA7 Regular codepoints (e.g. `music`→F025, `gear`→F443, `circle-info`→F059, `ticket`→F09D, `arrow-left`→F190) — all confirmed present in the installed font binary.
- **#4 Home nav**: Changed Home tab `onClick` to `popUpTo(0) { inclusive = true }` — removes `restoreState` bug that sent users back to Bands.
- **#5 News**: `NewsScreen` now opens `https://www.facebook.com/punkacidetom` in a Chrome Custom Tab via `LaunchedEffect`; WebView + HTML assets removed.
- **#6 Footer padding**: `AppNavHost` now receives `Modifier.padding(innerPadding)` from the Scaffold content lambda so content is not covered by the footer.
- **#7a Spotify**: `SpotifyPlayerComposable` height is now dynamic — JS interface reads `document.body.scrollHeight` after page load; minimum 80 dp.
- **#7b Spotify**: Entire Spotify section removed from `HomeScreen` (label, player, spacers, constant, imports); unused string keys removed from both `values/` and `values-en/` strings.xml.
- **#8 Splash**: `android:windowBackground` → `@color/pd_black`; `pd_black = #000000` added to `colors.xml`.
- **#9 Band images**: `Band.bandImageUrl` replaced by `bandImagePngUrl` / `bandImageJpgUrl` pointing to `/bands/` (not `/pd_resources/bands/`). `BandDetailScreen` tries PNG first, falls back to JPG on error.
- **#10 Font scale**: Normal mode `1.0f` → `1.12f`; large mode `1.30f` → `1.40f`.

## Test plan

- [ ] Fresh install on English-locale device shows Slovak UI
- [ ] Timetable shows bands positioned proportionally (late bands lower on scroll)
- [ ] All icons render (no `?` placeholders): music, gear, circle-info, ticket, arrow-left, heart
- [ ] Home tab in footer always navigates to Home, never Bands
- [ ] News tab opens Facebook immediately in Chrome Custom Tab
- [ ] All screens have visible bottom padding (content not behind footer)
- [ ] Spotify artist player on Band Detail shrinks/grows to content height
- [ ] Home screen has no Spotify section
- [ ] Splash screen is black (not navy)
- [ ] Band images load for `tamgasti-cz` (PNG first, JPG fallback)
- [ ] Text is ~12% larger than before in normal mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)