### PR TITLE
fix: enable core library desugaring in all feature modules

### DIFF
--- a/PD2026_app/feature/feature-info/build.gradle.kts
+++ b/PD2026_app/feature/feature-info/build.gradle.kts
@@ -12,6 +12,7 @@ android {
     compileSdk = 35
     defaultConfig { minSdk = 24 }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -20,6 +21,7 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
     implementation(project(":core:core-model"))
     implementation(project(":core:core-ui"))
     implementation(project(":core:core-data"))

--- a/PD2026_app/feature/feature-news/build.gradle.kts
+++ b/PD2026_app/feature/feature-news/build.gradle.kts
@@ -12,6 +12,7 @@ android {
     compileSdk = 35
     defaultConfig { minSdk = 24 }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -20,6 +21,7 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
     implementation(project(":core:core-model"))
     implementation(project(":core:core-ui"))
     implementation(libs.androidx.core.ktx)

--- a/PD2026_app/feature/feature-settings/build.gradle.kts
+++ b/PD2026_app/feature/feature-settings/build.gradle.kts
@@ -12,6 +12,7 @@ android {
     compileSdk = 35
     defaultConfig { minSdk = 24 }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -20,6 +21,7 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
     implementation(project(":core:core-model"))
     implementation(project(":core:core-ui"))
     implementation(project(":core:core-data"))

--- a/PD2026_app/feature/feature-spotify/build.gradle.kts
+++ b/PD2026_app/feature/feature-spotify/build.gradle.kts
@@ -12,6 +12,7 @@ android {
     compileSdk = 35
     defaultConfig { minSdk = 24 }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -23,6 +24,7 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
     implementation(project(":core:core-model"))
     implementation(project(":core:core-ui"))
     implementation(project(":core:core-data"))

--- a/PD2026_app/feature/feature-tickets/build.gradle.kts
+++ b/PD2026_app/feature/feature-tickets/build.gradle.kts
@@ -12,6 +12,7 @@ android {
     compileSdk = 35
     defaultConfig { minSdk = 24 }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -20,6 +21,7 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
     implementation(project(":core:core-model"))
     implementation(project(":core:core-ui"))
     implementation(libs.androidx.core.ktx)


### PR DESCRIPTION
## Summary

- `feature-news`, `feature-info`, `feature-settings`, `feature-spotify`, and `feature-tickets` were missing `isCoreLibraryDesugaringEnabled = true` + `coreLibraryDesugaring(libs.desugar.jdk.libs)`
- Their transitive dependencies (`core-model`, `core-ui`, `core-data`) use `java.time.*` APIs and publish AAR metadata that marks desugaring as required
- Without it the build fails at `checkDebugAndroidTestAarMetadata` with 2–3 issues per module
- `feature-bands`, `feature-home`, and `feature-timetable` already had this correctly configured — the fix brings the remaining 5 modules in line

## Test plan

- [ ] `gradle assembleDebug` completes without AAR metadata errors
- [ ] `gradle test` unit tests pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)