### PR TITLE
fix: remove bold weight from all 3rd Man font usages

### DIFF
--- a/PD2026_app/app/src/main/assets/info.html
+++ b/PD2026_app/app/src/main/assets/info.html
@@ -96,6 +96,7 @@
         /* ============ PAGE TITLE ============ */
         h1 {
             font-family: var(--f-big);
+            font-weight: normal;
             text-transform: uppercase;
             font-size: clamp(3.4rem, 14vw, 5.6rem);
             color: var(--fg);
@@ -114,6 +115,7 @@
         /* ============ SECTION TITLES (3rd Man) ============ */
         h2 {
             font-family: var(--f-big);
+            font-weight: normal;
             text-transform: uppercase;
             font-size: clamp(1.8rem, 6vw, 2.4rem);
             letter-spacing: 0.04em;

--- a/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
+++ b/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -192,7 +191,6 @@ private fun CountdownUnit(value: Long, label: String) {
             text = value.toString().padStart(2, '0'),
             style = MaterialTheme.typography.displayMedium,
             color = Crimson,
-            fontWeight = FontWeight.Bold,
         )
         Text(
             text = label,


### PR DESCRIPTION
## Summary

The 3rd Man font is a detailed decorative display font — rendering it bold (either explicitly or via browser font-weight synthesis) makes it harder to read.

**Two locations found and fixed:**

- **`info.html`** — `h1` and `h2` elements inherit `font-weight: bold` from the browser's UA stylesheet. The `@font-face` only declares the regular variant, so the browser synthesises a fake bold by thickening the strokes. Added `font-weight: normal` to both `h1` and `h2` CSS rules.

- **`HomeScreen.kt` `CountdownUnit`** — The countdown numbers use `MaterialTheme.typography.displayMedium` (which is already `ThirdManFontFamily` + `FontWeight.Normal`), but then explicitly override with `fontWeight = FontWeight.Bold`. Removed the override and the now-unused `FontWeight` import.

No other Kotlin files override the 3rd Man text styles with bold — `Typography.kt` declares all three display sizes as `FontWeight.Normal`.

## Test plan

- [ ] CI passes
- [ ] Info screen headings (INFO, Rady, Mapa areálu, …) render in regular-weight 3rd Man
- [ ] Home screen countdown numbers render in regular-weight 3rd Man

🤖 Generated with [Claude Code](https://claude.com/claude-code)