### PR TITLE
fix: apply all fixes from fixes_04.md (batch 04)

### DIFF
--- a/PD2026_app/app/src/main/res/values-en/strings.xml
+++ b/PD2026_app/app/src/main/res/values-en/strings.xml
@@ -20,6 +20,7 @@
     <string name="home_btn_timetable">Schedule</string>
     <string name="home_btn_info">Info</string>
     <string name="home_btn_tickets">Tickets &amp; Eshop</string>
+    <string name="home_social_heading">Social media</string>
     <string name="home_social_facebook">Facebook</string>
     <string name="home_social_instagram">Instagram</string>
 

--- a/PD2026_app/app/src/main/res/values/strings.xml
+++ b/PD2026_app/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="home_btn_timetable">Program</string>
     <string name="home_btn_info">Info</string>
     <string name="home_btn_tickets">Vstupenky &amp; Eshop</string>
+    <string name="home_social_heading">Sociálne siete</string>
     <string name="home_social_facebook">Facebook</string>
     <string name="home_social_instagram">Instagram</string>
 

--- a/PD2026_app/core/core-ui/src/main/kotlin/sk/punkacidetom/pd2026/core/ui/components/NowPlayingHeader.kt
+++ b/PD2026_app/core/core-ui/src/main/kotlin/sk/punkacidetom/pd2026/core/ui/components/NowPlayingHeader.kt
@@ -111,7 +111,7 @@ private fun NowPlayingRow(slot: NowPlayingSlot, onClick: () -> Unit) {
             modifier = Modifier.fillMaxWidth(),
         ) {
             FaIcon(
-                name = "music",
+                name = "play",
                 size = spacing.iconSm,
                 tint = Crimson,
                 modifier = Modifier.padding(end = spacing.sm),

--- a/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
+++ b/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
@@ -38,6 +38,7 @@ import sk.punkacidetom.pd2026.core.ui.theme.Navy
 import sk.punkacidetom.pd2026.core.ui.theme.NavyLight
 import sk.punkacidetom.pd2026.core.ui.theme.White
 import sk.punkacidetom.pd2026.core.ui.theme.WhiteAlpha60
+
 private const val URL_FACEBOOK = "https://www.facebook.com/punkacidetom"
 private const val URL_INSTAGRAM = "https://www.instagram.com/festival_punkaci_detom/"
 
@@ -85,7 +86,7 @@ fun HomeScreen(
 
         Spacer(modifier = Modifier.height(spacing.lg))
 
-        // Navigation buttons (2 per row)
+        // Navigation buttons — single column, full width
         val navButtons = listOf(
             Triple(stringResource(R.string.home_btn_news), "newspaper", onNavigateToNews),
             Triple(stringResource(R.string.home_btn_bands), "music", onNavigateToBands),
@@ -94,63 +95,43 @@ fun HomeScreen(
             Triple(stringResource(R.string.home_btn_tickets), "ticket", onNavigateToTickets),
         )
 
-        navButtons.chunked(2).forEach { rowItems ->
-            if (rowItems.size == 2) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-                ) {
-                    rowItems.forEach { (label, icon, onClick) ->
-                        HomeNavButton(label = label, icon = icon, onClick = onClick, modifier = Modifier.weight(1f))
-                    }
-                }
-            } else {
-                // Single item — occupies left half, right half is empty space
-                Row(modifier = Modifier.fillMaxWidth()) {
-                    val (label, icon, onClick) = rowItems[0]
-                    HomeNavButton(
-                        label = label,
-                        icon = icon,
-                        onClick = onClick,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Spacer(modifier = Modifier.weight(1f))
-                }
-            }
+        navButtons.forEach { (label, icon, onClick) ->
+            HomeNavButton(
+                label = label,
+                icon = icon,
+                onClick = onClick,
+                modifier = Modifier.fillMaxWidth(),
+            )
             Spacer(modifier = Modifier.height(spacing.sm))
         }
 
         Spacer(modifier = Modifier.height(spacing.lg))
 
-        // Social links
+        // Social links — stacked full width
         Text(
-            text = "Social",
+            text = stringResource(R.string.home_social_heading),
             style = MaterialTheme.typography.headlineSmall,
             color = White,
             modifier = Modifier.fillMaxWidth(),
         )
         Spacer(modifier = Modifier.height(spacing.sm))
-        Row(
+        SocialButton(
+            label = stringResource(R.string.home_social_facebook),
+            icon = "facebook",
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-        ) {
-            SocialButton(
-                label = stringResource(R.string.home_social_facebook),
-                icon = "facebook",
-                modifier = Modifier.weight(1f),
-                onClick = {
-                    CustomTabsIntent.Builder().build().launchUrl(context, Uri.parse(URL_FACEBOOK))
-                },
-            )
-            SocialButton(
-                label = stringResource(R.string.home_social_instagram),
-                icon = "instagram",
-                modifier = Modifier.weight(1f),
-                onClick = {
-                    CustomTabsIntent.Builder().build().launchUrl(context, Uri.parse(URL_INSTAGRAM))
-                },
-            )
-        }
+            onClick = {
+                CustomTabsIntent.Builder().build().launchUrl(context, Uri.parse(URL_FACEBOOK))
+            },
+        )
+        Spacer(modifier = Modifier.height(spacing.sm))
+        SocialButton(
+            label = stringResource(R.string.home_social_instagram),
+            icon = "instagram",
+            modifier = Modifier.fillMaxWidth(),
+            onClick = {
+                CustomTabsIntent.Builder().build().launchUrl(context, Uri.parse(URL_INSTAGRAM))
+            },
+        )
 
         Spacer(modifier = Modifier.height(spacing.xl))
     }
@@ -251,7 +232,13 @@ private fun SocialButton(
         modifier = modifier.height(spacing.buttonMinHeight),
         colors = ButtonDefaults.buttonColors(containerColor = NavyLight),
     ) {
-        FaIcon(name = icon, family = FaFamily.Brands, size = spacing.iconMd, tint = White, modifier = Modifier.padding(end = 6.dp))
+        FaIcon(
+            name = icon,
+            family = FaFamily.Brands,
+            size = spacing.iconMd,
+            tint = Crimson,   // was White
+            modifier = Modifier.padding(end = 6.dp),
+        )
         Text(
             text = label,
             style = MaterialTheme.typography.labelMedium,

--- a/PD2026_app/feature/feature-news/src/main/kotlin/sk/punkacidetom/pd2026/feature/news/NewsScreen.kt
+++ b/PD2026_app/feature/feature-news/src/main/kotlin/sk/punkacidetom/pd2026/feature/news/NewsScreen.kt
@@ -1,6 +1,9 @@
 package sk.punkacidetom.pd2026.feature.news
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,11 +11,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 
-private const val FACEBOOK_URL = "https://www.facebook.com/punkacidetom"
+/** Mobile Facebook page — lighter and less aggressive about redirecting to the app. */
+private const val FACEBOOK_URL = "https://m.facebook.com/punkacidetom"
+
+/** Chrome mobile UA so Facebook does not block the WebView. */
+private const val CHROME_UA =
+    "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 " +
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36"
 
 /**
  * Loads the festival Facebook page in an embedded WebView so the app header/footer
  * remain visible (unlike a Chrome Custom Tab which runs outside the scaffold).
+ *
+ * Spoofs the User-Agent so Facebook does not block the WebView, and intercepts
+ * fb:// / intent:// deep-links to forward them to the Facebook app (or silently
+ * ignore if not installed) instead of crashing the WebView.
  */
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -23,7 +36,29 @@ fun NewsScreen(modifier: Modifier = Modifier) {
             WebView(ctx).apply {
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = true
-                webViewClient = WebViewClient()
+                settings.useWideViewPort = true
+                settings.loadWithOverviewMode = true
+                settings.setSupportZoom(false)
+                settings.userAgentString = CHROME_UA
+                webViewClient = object : WebViewClient() {
+                    override fun shouldOverrideUrlLoading(
+                        view: WebView,
+                        request: WebResourceRequest,
+                    ): Boolean {
+                        val url = request.url
+                        return if (url.scheme == "fb" || url.scheme == "intent") {
+                            // Forward to Facebook app; silently ignore if not installed
+                            try {
+                                view.context.startActivity(
+                                    Intent(Intent.ACTION_VIEW, url)
+                                )
+                            } catch (_: ActivityNotFoundException) { }
+                            true   // consumed — do not load in WebView
+                        } else {
+                            false  // let WebView handle normal https:// URLs
+                        }
+                    }
+                }
                 loadUrl(FACEBOOK_URL)
             }
         },

--- a/PD2026_app/feature/feature-timetable/src/main/kotlin/sk/punkacidetom/pd2026/feature/timetable/TimetableScreen.kt
+++ b/PD2026_app/feature/feature-timetable/src/main/kotlin/sk/punkacidetom/pd2026/feature/timetable/TimetableScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -129,6 +130,7 @@ fun TimetableScreen(
             Text(
                 text = Stages.displayName("A"),
                 style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
                 color = Crimson,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),
@@ -137,6 +139,7 @@ fun TimetableScreen(
             Text(
                 text = Stages.displayName("B"),
                 style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
                 color = Crimson,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f),


### PR DESCRIPTION
## Summary

- **#1a Nav buttons** — replaced 2-per-row chunked layout with a single full-width column; social buttons also stacked vertically (full-width each).
- **#1b Social heading** — hardcoded `"Social"` replaced with `stringResource(R.string.home_social_heading)`; new string added to both locale files (`sk`: "Sociálne siete", `en`: "Social media").
- **#1c Social icons** — `FaIcon` tint in `SocialButton` changed from `White` → `Crimson`.
- **#2 NowPlayingHeader** — icon changed from `"music"` to `"play"` (the circle-play glyph already mapped in `FaCodes.kt`).
- **#3 Stage headers** — `FontWeight.Bold` added to both stage name `Text` composables in `TimetableScreen` so they're visually distinct from card content.
- **#4 News / Facebook WebView** — four improvements: mobile URL (`m.facebook.com`), Chrome Mobile UA string, `fb://`/`intent://` deep-link interception via custom `WebViewClient`, and `useWideViewPort` / `loadWithOverviewMode` / `setSupportZoom(false)`.

## Test plan

- [ ] CI passes
- [ ] Home: all 5 nav buttons stack in a single column, full width
- [ ] Home: Facebook and Instagram buttons stack vertically, icons are Crimson
- [ ] Home: "Sociálne siete" / "Social media" heading appears above social buttons
- [ ] NowPlayingHeader: shows ▶ play icon (not ♪ music note)
- [ ] Timetable: stage name headers "Main Stage" / "Stage B" appear bold
- [ ] News: Facebook page loads without blank/error screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)