### PR TITLE
fix: move home_social_heading to feature-home R scope

### DIFF
--- a/PD2026_app/app/src/main/res/values-en/strings.xml
+++ b/PD2026_app/app/src/main/res/values-en/strings.xml
@@ -20,7 +20,6 @@
     <string name="home_btn_timetable">Schedule</string>
     <string name="home_btn_info">Info</string>
     <string name="home_btn_tickets">Tickets &amp; Eshop</string>
-    <string name="home_social_heading">Social media</string>
     <string name="home_social_facebook">Facebook</string>
     <string name="home_social_instagram">Instagram</string>
 

--- a/PD2026_app/app/src/main/res/values/strings.xml
+++ b/PD2026_app/app/src/main/res/values/strings.xml
@@ -20,7 +20,6 @@
     <string name="home_btn_timetable">Program</string>
     <string name="home_btn_info">Info</string>
     <string name="home_btn_tickets">Vstupenky &amp; Eshop</string>
-    <string name="home_social_heading">Sociálne siete</string>
     <string name="home_social_facebook">Facebook</string>
     <string name="home_social_instagram">Instagram</string>
 

--- a/PD2026_app/feature/feature-home/src/main/res/values-en/strings.xml
+++ b/PD2026_app/feature/feature-home/src/main/res/values-en/strings.xml
@@ -5,6 +5,7 @@
     <string name="home_btn_timetable">Timetable</string>
     <string name="home_btn_info">Info</string>
     <string name="home_btn_tickets">Tickets &amp; Eshop</string>
+    <string name="home_social_heading">Social media</string>
     <string name="home_social_facebook">Facebook</string>
     <string name="home_social_instagram">Instagram</string>
     <string name="home_countdown_until">Until festival start</string>

--- a/PD2026_app/feature/feature-home/src/main/res/values/strings.xml
+++ b/PD2026_app/feature/feature-home/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="home_btn_timetable">Program</string>
     <string name="home_btn_info">Info</string>
     <string name="home_btn_tickets">Vstupenky &amp; Eshop</string>
+    <string name="home_social_heading">Sociálne siete</string>
     <string name="home_social_facebook">Facebook</string>
     <string name="home_social_instagram">Instagram</string>
     <string name="home_countdown_until">Do štartu festivalu</string>


### PR DESCRIPTION
## Summary
- `home_social_heading` was added to `app/src/main/res/values/` in batch-04, but `HomeScreen.kt` is in the `feature-home` module which has its own R class and cannot see app-module strings
- Moves the key (Slovak + English) to `feature/feature-home/src/main/res/values{,-en}/strings.xml`
- Removes the stray copy from the app module

## Root cause
Each Gradle module generates its own R class. `stringResource(R.string.foo)` in `feature-home` resolves only strings declared in that module's own `res/` directories.

## Test plan
- [ ] `./gradlew :feature:feature-home:compileDebugKotlin` — must succeed (was failing with `Unresolved reference 'home_social_heading'`)
- [ ] Full debug build passes
- [ ] Home screen shows "Sociálne siete" heading (SK) / "Social media" heading (EN) above the social buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)