### PR TITLE
fix(batch-05): font scale, nav bar, home order, LazyColumn detail, cold-start fetch

### DIFF
--- a/PD2026_app/app/src/main/kotlin/sk/punkacidetom/pd2026/MainActivity.kt
+++ b/PD2026_app/app/src/main/kotlin/sk/punkacidetom/pd2026/MainActivity.kt
@@ -56,7 +56,7 @@ class MainActivity : AppCompatActivity() {
 
         setContent {
             val isFontLarge by userPrefs.isFontLarge.collectAsState(initial = false)
-            val fontScale = if (isFontLarge) 1.40f else 1.12f
+            val fontScale = if (isFontLarge) 1.60f else 1.12f
 
             // Collect bands for NowPlayingHeader + start-destination decision
             val bands by bandRepository.observeBands().collectAsState(initial = emptyList())

--- a/PD2026_app/app/src/main/kotlin/sk/punkacidetom/pd2026/navigation/AppBottomBar.kt
+++ b/PD2026_app/app/src/main/kotlin/sk/punkacidetom/pd2026/navigation/AppBottomBar.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -40,6 +41,7 @@ fun AppBottomBar(navController: NavHostController) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .navigationBarsPadding()
             .height(spacing.bottomNavHeight)
             .background(NavyDark),
         horizontalArrangement = Arrangement.SpaceEvenly,

--- a/PD2026_app/core/core-data/src/main/kotlin/sk/punkacidetom/pd2026/core/data/repository/BandRepositoryImpl.kt
+++ b/PD2026_app/core/core-data/src/main/kotlin/sk/punkacidetom/pd2026/core/data/repository/BandRepositoryImpl.kt
@@ -42,9 +42,8 @@ class BandRepositoryImpl @Inject constructor(
             val cached = cache.loadBands()
             if (cached.isNotEmpty()) _bands.value = cached
 
-            // Auto-refresh on app start (ignores cooldown for initial load — but
-            // if cache is very fresh we skip the network hit)
-            backgroundRefreshIfStale(ignoreCooldown = false)
+            // App start always fetches fresh data regardless of cooldown
+            backgroundRefreshIfStale(ignoreCooldown = true)
         }
     }
 

--- a/PD2026_app/feature/feature-bands/src/main/kotlin/sk/punkacidetom/pd2026/feature/bands/BandDetailScreen.kt
+++ b/PD2026_app/feature/feature-bands/src/main/kotlin/sk/punkacidetom/pd2026/feature/bands/BandDetailScreen.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -56,47 +54,48 @@ fun BandDetailScreen(
     val context = LocalContext.current
     val band = uiState.band
 
-    Column(
+    LazyColumn(
         modifier = modifier
             .fillMaxSize()
-            .background(Navy)
-            .verticalScroll(rememberScrollState()),
+            .background(Navy),
     ) {
-        // Back button over the image
-        Box {
-            // Header image with gradient fade
-            BandHeaderImage(
-                band = band,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(spacing.bandImageHeight),
-            )
-
-            IconButton(
-                onClick = onBack,
-                modifier = Modifier
-                    .padding(spacing.sm)
-                    .align(Alignment.TopStart),
-            ) {
-                FaIcon(name = "arrow-left", size = spacing.iconLg, tint = White)
+        // Header image + back button
+        item(key = "header") {
+            Box {
+                BandHeaderImage(
+                    band = band,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(spacing.bandImageHeight),
+                )
+                IconButton(
+                    onClick = onBack,
+                    modifier = Modifier
+                        .padding(spacing.sm)
+                        .align(Alignment.TopStart),
+                ) {
+                    FaIcon(name = "arrow-left", size = spacing.iconLg, tint = White)
+                }
             }
         }
 
         if (band == null) {
-            Text(
-                text = "…",
-                color = WhiteAlpha60,
-                modifier = Modifier.padding(spacing.md),
-            )
-            return@Column
+            item(key = "loading") {
+                Text(
+                    text = "…",
+                    color = WhiteAlpha60,
+                    modifier = Modifier.padding(spacing.md),
+                )
+            }
+            return@LazyColumn
         }
 
-        Column(modifier = Modifier.padding(horizontal = spacing.md)) {
-            Spacer(modifier = Modifier.height(spacing.sm))
-
-            // Name + favourite toggle
+        // Name + favourite toggle
+        item(key = "name") {
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = spacing.sm, start = spacing.md, end = spacing.md),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
@@ -113,67 +112,66 @@ fun BandDetailScreen(
                     )
                 }
             }
+        }
 
-            if (band.genre.isNotBlank()) {
+        // Genre
+        if (band.genre.isNotBlank()) {
+            item(key = "genre") {
                 Text(
                     text = band.genre,
                     style = MaterialTheme.typography.titleMedium,
                     color = Crimson,
+                    modifier = Modifier.padding(horizontal = spacing.md),
                 )
             }
+        }
 
-            Spacer(modifier = Modifier.height(spacing.sm))
-
-            // Day, date, time
+        // Day / time / stage
+        item(key = "datetime") {
             val dayName = band.startDate.dayOfWeek
                 .getDisplayName(TextStyle.FULL, Locale.forLanguageTag(uiState.language))
                 .replaceFirstChar { it.uppercase() }
             val dateStr = "${band.startDate.dayOfMonth}. ${band.startDate.monthValue}. ${band.startDate.year}"
             val timeStr = "${band.startTime.hour}:${band.startTime.minute.toString().padStart(2, '0')}" +
                 " – ${band.endTime.hour}:${band.endTime.minute.toString().padStart(2, '0')}"
+            Column(modifier = Modifier.padding(horizontal = spacing.md)) {
+                Spacer(modifier = Modifier.height(spacing.sm))
+                Text(text = "$dayName, $dateStr", style = MaterialTheme.typography.bodyMedium, color = WhiteAlpha60)
+                Text(text = timeStr, style = MaterialTheme.typography.titleSmall, color = White)
+                Spacer(modifier = Modifier.height(spacing.xs))
+                Text(text = Stages.displayName(band.stageCode), style = MaterialTheme.typography.bodyMedium, color = WhiteAlpha60)
+                Spacer(modifier = Modifier.height(spacing.md))
+            }
+        }
 
-            Text(
-                text = "$dayName, $dateStr",
-                style = MaterialTheme.typography.bodyMedium,
-                color = WhiteAlpha60,
-            )
-            Text(
-                text = timeStr,
-                style = MaterialTheme.typography.titleSmall,
-                color = White,
-            )
-
-            Spacer(modifier = Modifier.height(spacing.xs))
-
-            Text(
-                text = Stages.displayName(band.stageCode),
-                style = MaterialTheme.typography.bodyMedium,
-                color = WhiteAlpha60,
-            )
-
-            Spacer(modifier = Modifier.height(spacing.md))
-
-            // Description (show nothing when blank — no placeholder text)
-            val description = band.description(uiState.language)
-            if (description.isNotBlank()) {
+        // Description — in its own item so long text never bloats a shared layer
+        val description = band.description(uiState.language)
+        if (description.isNotBlank()) {
+            item(key = "description") {
                 Text(
                     text = description,
                     style = MaterialTheme.typography.bodyMedium,
                     color = White,
+                    modifier = Modifier.padding(horizontal = spacing.md),
                 )
             }
+        }
 
-            // Spotify player (only for acts with a Spotify artist ID)
-            if (band.spotifyArtistId.isNotBlank()) {
+        // Spotify player
+        if (band.spotifyArtistId.isNotBlank()) {
+            item(key = "spotify") {
                 Spacer(modifier = Modifier.height(spacing.md))
                 SpotifyPlayerComposable(
                     embedUrl = spotifyArtistEmbedUrl(band.spotifyArtistId),
                     openLabel = stringResource(R.string.band_detail_open_spotify),
                     onOpenClick = { SpotifyLauncher.openArtist(context, band.spotifyArtistId) },
                     embedHeight = 152,
+                    modifier = Modifier.padding(horizontal = spacing.md),
                 )
             }
+        }
 
+        item(key = "bottom_spacer") {
             Spacer(modifier = Modifier.height(spacing.xl))
         }
     }
@@ -182,7 +180,6 @@ fun BandDetailScreen(
 @Composable
 private fun BandHeaderImage(band: Band?, modifier: Modifier = Modifier) {
     val spacing = LocalAppSpacing.current
-    // remember must be called unconditionally (Rules of Composables)
     var usePng by remember(band?.imageName) { mutableStateOf(true) }
     val imageUrl = when {
         band == null || band.bandImagePngUrl.isBlank() -> ""
@@ -203,7 +200,6 @@ private fun BandHeaderImage(band: Band?, modifier: Modifier = Modifier) {
                 modifier = Modifier.fillMaxSize(),
             )
         } else {
-            // Fallback: plain navy background with band initial
             Box(
                 modifier = Modifier
                     .fillMaxSize()

--- a/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
+++ b/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
@@ -88,9 +88,9 @@ fun HomeScreen(
 
         // Navigation buttons — single column, full width
         val navButtons = listOf(
-            Triple(stringResource(R.string.home_btn_news), "newspaper", onNavigateToNews),
-            Triple(stringResource(R.string.home_btn_bands), "music", onNavigateToBands),
+            // Triple(stringResource(R.string.home_btn_news), "newspaper", onNavigateToNews),  // hidden until News is ready
             Triple(stringResource(R.string.home_btn_timetable), "calendar", onNavigateToTimetable),
+            Triple(stringResource(R.string.home_btn_bands), "music", onNavigateToBands),
             Triple(stringResource(R.string.home_btn_info), "circle-info", onNavigateToInfo),
             Triple(stringResource(R.string.home_btn_tickets), "ticket", onNavigateToTickets),
         )


### PR DESCRIPTION
## Summary

| # | Fix | File(s) |
|---|-----|---------|
| 1 | Large font scale 1.40 → **1.60** | `MainActivity.kt` |
| 2 | System nav bar covers bottom tab row → add `navigationBarsPadding()` | `AppBottomBar.kt` |
| 3 | Hide News button (commented out); reorder: **Schedule → Bands → Info → Tickets** | `HomeScreen.kt` |
| 4 | `BandDetailScreen` crash (RenderThread SIGSEGV) on large font + long description → replace `Column+verticalScroll` with `LazyColumn` | `BandDetailScreen.kt` |
| 5 | Cold-start shows stale cached data → `ignoreCooldown false→true` in `init` block | `BandRepositoryImpl.kt` |

## Details

**Fix 2 — nav bar insets:** `enableEdgeToEdge()` makes the app draw behind the system nav bar. With `contentWindowInsets = WindowInsets(0)` suppressing auto-insets, nothing was pushing the tab row up. `navigationBarsPadding()` on the Row fixes this without affecting tap-target size.

**Fix 4 — LazyColumn:** `Column+verticalScroll` allocates a single hardware layer for the entire content height. At 1.60× font scale on a 3× density screen, long descriptions can exceed the GPU's max texture size (4096–8192 px) → `fault addr 0x28` SIGSEGV in RenderThread. `LazyColumn` renders only visible items and never hits this limit.

**Fix 5 — cold-start fetch:** `ignoreCooldown = false` in `init` caused the 30-min guard to fire on cold start, serving stale cache if the app was used within the last 30 min. `ignoreCooldown = true` in `init` + `false` in `onResume` matches the spec (always fetch on start, cooldown on resume).

## Test plan
- [ ] Large font renders timetable cards correctly at wider scale
- [ ] System nav bar no longer overlaps bottom tab row (Android 13+)
- [ ] Home screen shows Schedule first, News button absent
- [ ] Band detail with long description + large font does not crash
- [ ] Cold start fetches fresh data even if app was recently used

🤖 Generated with [Claude Code](https://claude.com/claude-code)