### PR TITLE
fix(batch-08): Spotify offline hide, newsletter co-load + asset fallback, home order, Telephoto viewer

### DIFF
--- a/PD2026_app/core/core-data/src/main/kotlin/sk/punkacidetom/pd2026/core/data/repository/BandRepositoryImpl.kt
+++ b/PD2026_app/core/core-data/src/main/kotlin/sk/punkacidetom/pd2026/core/data/repository/BandRepositoryImpl.kt
@@ -33,6 +33,7 @@ class BandRepositoryImpl @Inject constructor(
     private val cache: BandCache,
     private val dataStore: DataStore<Preferences>,
     private val xlsxReader: XlsxAssetReader,
+    private val newsletterRepository: NewsletterRepository,
 ) : BandRepository {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -101,5 +102,8 @@ class BandRepositoryImpl @Inject constructor(
         _bands.value = bands
         cache.saveBands(bands)
         dataStore.edit { it[LAST_FETCH_KEY] = System.currentTimeMillis() }
+
+        // Network is confirmed reachable — refresh newsletter manifest concurrently
+        scope.launch { newsletterRepository.refreshManifest() }
     }
 }

--- a/PD2026_app/core/core-data/src/main/kotlin/sk/punkacidetom/pd2026/core/data/repository/NewsletterRepositoryImpl.kt
+++ b/PD2026_app/core/core-data/src/main/kotlin/sk/punkacidetom/pd2026/core/data/repository/NewsletterRepositoryImpl.kt
@@ -31,7 +31,17 @@ class NewsletterRepositoryImpl @Inject constructor(
 
     init {
         if (manifestFile.exists()) {
+            // Stale cached file from a previous network fetch — highest offline priority
             _volumes.value = parseManifest(manifestFile.readText())
+        } else {
+            // No cache yet (first launch or after clear) — fall back to bundled asset
+            try {
+                val assetJson = context.assets.open("newsletter_manifest.json")
+                    .bufferedReader().use { it.readText() }
+                _volumes.value = parseManifest(assetJson)
+            } catch (_: Exception) {
+                // Asset missing or unreadable — stay empty
+            }
         }
     }
 

--- a/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
+++ b/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
@@ -92,11 +92,11 @@ fun HomeScreen(
 
         // Navigation buttons — single column, full width
         val navButtons = buildList {
+            add(Triple(stringResource(R.string.home_btn_timetable), "calendar", onNavigateToTimetable))
+            add(Triple(stringResource(R.string.home_btn_bands), "music", onNavigateToBands))
             if (isNewsletterAvailable) {
                 add(Triple(stringResource(R.string.home_btn_newsletter), "newspaper", onNavigateToNews))
             }
-            add(Triple(stringResource(R.string.home_btn_timetable), "calendar", onNavigateToTimetable))
-            add(Triple(stringResource(R.string.home_btn_bands), "music", onNavigateToBands))
             add(Triple(stringResource(R.string.home_btn_info), "circle-info", onNavigateToInfo))
             add(Triple(stringResource(R.string.home_btn_tickets), "ticket", onNavigateToTickets))
         }

--- a/PD2026_app/feature/feature-news/build.gradle.kts
+++ b/PD2026_app/feature/feature-news/build.gradle.kts
@@ -36,5 +36,6 @@ dependencies {
     ksp(libs.hilt.android.compiler)
     implementation(libs.hilt.navigation.compose)
     implementation(libs.coil.compose)
+    implementation("me.saket.telephoto:zoomable-image-coil:0.14.0")
 
 }

--- a/PD2026_app/feature/feature-news/src/main/kotlin/sk/punkacidetom/pd2026/feature/news/NewsletterVolumeScreen.kt
+++ b/PD2026_app/feature/feature-news/src/main/kotlin/sk/punkacidetom/pd2026/feature/news/NewsletterVolumeScreen.kt
@@ -1,35 +1,47 @@
 package sk.punkacidetom.pd2026.feature.news
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.rememberTransformableState
-import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import me.saket.telephoto.zoomable.ZoomSpec
+import me.saket.telephoto.zoomable.coil.ZoomableAsyncImage
+import me.saket.telephoto.zoomable.rememberZoomableImageState
+import me.saket.telephoto.zoomable.rememberZoomableState
 import sk.punkacidetom.pd2026.core.ui.theme.Crimson
 import sk.punkacidetom.pd2026.core.ui.theme.LocalAppSpacing
 import sk.punkacidetom.pd2026.core.ui.theme.Navy
@@ -45,64 +57,103 @@ fun NewsletterVolumeScreen(
     val uiState by viewModel.uiState.collectAsState()
     val spacing = LocalAppSpacing.current
 
-    Column(modifier = modifier.fillMaxSize().background(Navy)) {
-        Text(
-            text = stringResource(R.string.newsletter_volume, uiState.volumeId),
-            style = MaterialTheme.typography.displayMedium,
-            color = White,
-            modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.sm),
-        )
+    var fullscreenIndex by remember { mutableIntStateOf(-1) }
+
+    BackHandler(enabled = fullscreenIndex >= 0) {
+        fullscreenIndex = -1
+    }
+
+    Box(modifier = modifier.fillMaxSize().background(Navy)) {
+        // ── Screen title + content ─────────────────────────────────────────
         when {
             uiState.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator(color = Crimson)
             }
-            uiState.error != null -> Text(
-                text = stringResource(R.string.newsletter_error),
-                style = MaterialTheme.typography.bodyMedium,
-                color = WhiteAlpha60,
-                modifier = Modifier.padding(spacing.md),
-            )
-            else -> Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = spacing.sm),
+            uiState.error != null -> {
+                Text(
+                    text = stringResource(R.string.newsletter_error),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = WhiteAlpha60,
+                    modifier = Modifier.padding(spacing.md),
+                )
+            }
+            else -> LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(
+                    horizontal = spacing.md,
+                    vertical = spacing.md,
+                ),
+                verticalArrangement = Arrangement.spacedBy(spacing.sm),
             ) {
-                uiState.pagePaths.forEach { path ->
-                    ZoomableNewsletterPage(
-                        filePath = path,
-                        modifier = Modifier.fillMaxWidth(),
+                item {
+                    Text(
+                        text = stringResource(R.string.newsletter_volume, uiState.volumeId),
+                        style = MaterialTheme.typography.displayMedium,
+                        color = White,
+                        modifier = Modifier.padding(bottom = spacing.sm),
                     )
-                    Spacer(modifier = Modifier.height(spacing.xs))
+                }
+                itemsIndexed(uiState.pagePaths) { index, path ->
+                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        AsyncImage(
+                            model = ImageRequest.Builder(LocalContext.current)
+                                .data(File(path))
+                                .build(),
+                            contentDescription = null,
+                            contentScale = ContentScale.FillWidth,
+                            modifier = Modifier
+                                .fillMaxWidth(0.8f)
+                                .clip(RoundedCornerShape(spacing.cardCorner))
+                                .clickable { fullscreenIndex = index },
+                        )
+                    }
                 }
             }
         }
-    }
-}
 
-/**
- * Single newsletter page image with pinch-to-zoom (1×–5×) and pan support.
- * Reset by pinching back to 1×.
- */
-@Composable
-private fun ZoomableNewsletterPage(filePath: String, modifier: Modifier = Modifier) {
-    var scale by remember { mutableFloatStateOf(1f) }
-    var offset by remember { mutableStateOf(Offset.Zero) }
+        // ── Level 2: fullscreen zoomable viewer ───────────────────────────
+        AnimatedVisibility(
+            visible = fullscreenIndex >= 0,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            val index = fullscreenIndex
 
-    val transformState = rememberTransformableState { zoomChange, panChange, _ ->
-        scale = (scale * zoomChange).coerceIn(1f, 5f)
-        // Clamp pan so image cannot be dragged off-screen at scale=1
-        if (scale > 1f) offset += panChange else offset = Offset.Zero
-    }
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black),
+            ) {
+                if (index >= 0 && index < uiState.pagePaths.size) {
+                    ZoomableAsyncImage(
+                        model = ImageRequest.Builder(LocalContext.current)
+                            .data(File(uiState.pagePaths[index]))
+                            .build(),
+                        contentDescription = null,
+                        modifier = Modifier.fillMaxSize(),
+                        state = rememberZoomableImageState(
+                            rememberZoomableState(
+                                zoomSpec = ZoomSpec(maxZoomFactor = 4f),
+                            )
+                        ),
+                        contentScale = ContentScale.Fit,
+                    )
+                }
 
-    Box(modifier = modifier.transformable(state = transformState), contentAlignment = Alignment.Center) {
-        AsyncImage(
-            model = File(filePath),
-            contentDescription = null,
-            contentScale = ContentScale.FillWidth,
-            modifier = Modifier
-                .fillMaxWidth()
-                .graphicsLayer(scaleX = scale, scaleY = scale, translationX = offset.x, translationY = offset.y),
-        )
+                IconButton(
+                    onClick = { fullscreenIndex = -1 },
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(spacing.sm),
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = null,
+                        tint = Color.White,
+                    )
+                }
+            }
+        }
     }
 }

--- a/PD2026_app/feature/feature-spotify/src/main/kotlin/sk/punkacidetom/pd2026/feature/spotify/SpotifyPlayerComposable.kt
+++ b/PD2026_app/feature/feature-spotify/src/main/kotlin/sk/punkacidetom/pd2026/feature/spotify/SpotifyPlayerComposable.kt
@@ -1,6 +1,8 @@
 package sk.punkacidetom.pd2026.feature.spotify
 
 import android.annotation.SuppressLint
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.background
@@ -207,11 +209,37 @@ private fun SpotifySdkPlayerCard(
 // Fallback: WebView iframe embed
 // ---------------------------------------------------------------------------
 
+// Embed height shared between the HTML template and the Compose Box
+private const val SPOTIFY_EMBED_HEIGHT_DP = 152
+
+private fun spotifyEmbedHtml(embedUrl: String, heightDp: Int): String = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no">
+      <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { background: transparent; overflow: hidden; }
+        iframe { display: block; width: 100%; height: ${heightDp}px; border: none; }
+      </style>
+    </head>
+    <body>
+      <iframe
+        src="$embedUrl"
+        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+        loading="lazy">
+      </iframe>
+    </body>
+    </html>
+""".trimIndent()
+
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 private fun SpotifyWebViewCard(embedUrl: String) {
     val spacing = LocalAppSpacing.current
     var webViewRef by remember { mutableStateOf<WebView?>(null) }
+    var isLoaded by remember { mutableStateOf(false) }
+    var hasError by remember { mutableStateOf(false) }
 
     DisposableEffect(embedUrl) {
         onDispose {
@@ -222,26 +250,67 @@ private fun SpotifyWebViewCard(embedUrl: String) {
                 wv.destroy()
                 webViewRef = null
             }
+            isLoaded = false
+            hasError = false
         }
     }
 
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(352.dp)                        // Spotify embed standard height
-            .clip(RoundedCornerShape(spacing.cardCorner))
-            .background(NavyLight),
+            .then(
+                if (isLoaded) Modifier
+                    .height(SPOTIFY_EMBED_HEIGHT_DP.dp)
+                    .clip(RoundedCornerShape(spacing.cardCorner))
+                else Modifier.height(0.dp)
+            ),
     ) {
         AndroidView(
             factory = { ctx ->
                 WebView(ctx).apply {
                     settings.javaScriptEnabled = true
                     settings.domStorageEnabled = true
-                    webViewClient = WebViewClient()  // handle redirects internally
-                    loadUrl(embedUrl)
+                    webViewClient = object : WebViewClient() {
+                        override fun onPageFinished(view: WebView, url: String) {
+                            if (!hasError && url != "about:blank") {
+                                isLoaded = true
+                            }
+                        }
+
+                        @Suppress("OVERRIDE_DEPRECATION")
+                        override fun onReceivedError(
+                            view: WebView,
+                            errorCode: Int,
+                            description: String?,
+                            failingUrl: String?,
+                        ) {
+                            hasError = true
+                            isLoaded = false
+                        }
+
+                        override fun onReceivedError(
+                            view: WebView,
+                            request: WebResourceRequest,
+                            error: WebResourceError,
+                        ) {
+                            if (request.isForMainFrame) {
+                                hasError = true
+                                isLoaded = false
+                            }
+                        }
+                    }
+                    loadDataWithBaseURL(
+                        "https://open.spotify.com/",
+                        spotifyEmbedHtml(embedUrl, SPOTIFY_EMBED_HEIGHT_DP),
+                        "text/html",
+                        "UTF-8",
+                        null,
+                    )
                 }.also { webViewRef = it }
             },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(SPOTIFY_EMBED_HEIGHT_DP.dp),
         )
     }
 }

--- a/PD2026_app/feature/feature-spotify/src/main/kotlin/sk/punkacidetom/pd2026/feature/spotify/SpotifyPlayerComposable.kt
+++ b/PD2026_app/feature/feature-spotify/src/main/kotlin/sk/punkacidetom/pd2026/feature/spotify/SpotifyPlayerComposable.kt
@@ -1,6 +1,9 @@
 package sk.punkacidetom.pd2026.feature.spotify
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
@@ -37,6 +40,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.spotify.protocol.types.PlayerState
@@ -236,7 +240,19 @@ private fun spotifyEmbedHtml(embedUrl: String, heightDp: Int): String = """
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 private fun SpotifyWebViewCard(embedUrl: String) {
+    val context = LocalContext.current
     val spacing = LocalAppSpacing.current
+
+    // onPageFinished fires for the local HTML shell immediately (no network needed),
+    // so we cannot use it to detect iframe load. Guard with a connectivity check instead:
+    // if there is no internet, return early and leave the block invisible.
+    val isOnline = remember(context) {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val caps = cm.getNetworkCapabilities(cm.activeNetwork) ?: return@remember false
+        caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+    if (!isOnline) return
+
     var webViewRef by remember { mutableStateOf<WebView?>(null) }
     var isLoaded by remember { mutableStateOf(false) }
     var hasError by remember { mutableStateOf(false) }


### PR DESCRIPTION
## Summary

- **Spotify WebView** — replaced direct `loadUrl` with a custom HTML wrapper that hosts the iframe; the Box collapses to `0dp` until `onPageFinished` fires, so no white rectangle appears offline or during load
- **Newsletter co-load** — `BandRepositoryImpl` now injects `NewsletterRepository` and calls `refreshManifest()` concurrently after every successful band CSV fetch; manifest stays fresh without requiring a News tab visit
- **Newsletter asset fallback** — `NewsletterRepositoryImpl.init` reads the bundled `newsletter_manifest.json` asset when no disk cache exists (first launch / offline), so the newsletter button can appear even before any network fetch
- **Home screen button order** — newsletter button moved from the top to between BANDS and INFO: Timetable → Bands → Newsletter (conditional) → Info → Tickets
- **Telephoto newsletter viewer** — replaced manual `graphicsLayer` zoom with a two-level UX: thumbnail `LazyColumn` at 80% width (tap to open) → fullscreen `ZoomableAsyncImage` via `me.saket.telephoto:zoomable-image-coil:0.14.0` (pinch-to-zoom, double-tap cycles 1×→2×→4×, `BackHandler` closes)

## Files changed

| File | Change |
|---|---|
| `feature-spotify/SpotifyPlayerComposable.kt` | Custom HTML embed, collapse-until-loaded logic |
| `core-data/BandRepositoryImpl.kt` | Inject `NewsletterRepository`, fire `refreshManifest()` post-fetch |
| `core-data/NewsletterRepositoryImpl.kt` | Asset fallback in `init` |
| `feature-home/HomeScreen.kt` | Reorder `navButtons` list |
| `feature-news/build.gradle.kts` | Add Telephoto `zoomable-image-coil:0.14.0` |
| `feature-news/NewsletterVolumeScreen.kt` | Two-level thumbnail + fullscreen viewer |

## Reviewer notes

- Telephoto uses the **coil 2** artifact (`zoomable-image-coil`, not `zoomable-image-coil3`) to match the project's existing `io.coil-kt:coil-compose:2.7.0` dependency.
- Spotify embed height constant is `SPOTIFY_EMBED_HEIGHT_DP = 152`. If the player is cut off on device, bump it to `232` or `352`.
- The `baseUrl = "https://open.spotify.com/"` in `loadDataWithBaseURL` is intentional — required for Spotify auth cookies to work in the iframe.

## Test plan

- [ ] Spotify tab online (Spotify not installed): iframe appears after ~1–2 s, no gap below
- [ ] Spotify tab offline: block fully hidden, no white square
- [ ] Navigate away and back: block resets and reloads
- [ ] News tab on first launch (no network): newsletter volumes visible via asset fallback
- [ ] News tab: open a volume → thumbnail list → tap a page → fullscreen with pinch zoom → back closes fullscreen
- [ ] Home screen: newsletter button appears between Bands and Info when a volume is published