### PR TITLE
fix(ui): countdown red bg, newsletter red buttons, band header compact for logo fallback

### DIFF
--- a/PD2026_app/feature/feature-bands/src/main/kotlin/sk/punkacidetom/pd2026/feature/bands/BandDetailScreen.kt
+++ b/PD2026_app/feature/feature-bands/src/main/kotlin/sk/punkacidetom/pd2026/feature/bands/BandDetailScreen.kt
@@ -78,12 +78,14 @@ fun BandDetailScreen(
     ) {
         // Header image + back button
         item(key = "header") {
+            val hasPhoto = band != null && band.bandImagePngUrl.isNotBlank()
+            val headerHeight = if (hasPhoto) spacing.bandImageHeight else spacing.bandImageHeight * 0.45f
             Box {
                 BandHeaderImage(
                     band = band,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(spacing.bandImageHeight),
+                        .height(headerHeight),
                 )
                 IconButton(
                     onClick = onBack,

--- a/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
+++ b/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
@@ -148,14 +148,14 @@ private fun CountdownBlock(countdown: CountdownState, paddingMd: androidx.compos
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(NavyLight, shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp))
+            .background(Crimson, shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp))
             .padding(paddingMd),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             text = stringResource(R.string.home_countdown_until),
             style = MaterialTheme.typography.titleMedium,
-            color = WhiteAlpha60,
+            color = White,
             textAlign = TextAlign.Center,
         )
         Spacer(modifier = Modifier.height(8.dp))
@@ -177,12 +177,12 @@ private fun CountdownUnit(value: Long, label: String) {
         Text(
             text = value.toString().padStart(2, '0'),
             style = MaterialTheme.typography.displayMedium,
-            color = Crimson,
+            color = White,
         )
         Text(
             text = label,
             style = MaterialTheme.typography.labelSmall,
-            color = WhiteAlpha60,
+            color = White,
         )
     }
 }

--- a/PD2026_app/feature/feature-news/src/main/kotlin/sk/punkacidetom/pd2026/feature/news/NewsScreen.kt
+++ b/PD2026_app/feature/feature-news/src/main/kotlin/sk/punkacidetom/pd2026/feature/news/NewsScreen.kt
@@ -16,10 +16,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import sk.punkacidetom.pd2026.core.ui.theme.LocalAppSpacing
+import sk.punkacidetom.pd2026.core.ui.theme.Crimson
 import sk.punkacidetom.pd2026.core.ui.theme.Navy
 import sk.punkacidetom.pd2026.core.ui.theme.White
 import sk.punkacidetom.pd2026.core.ui.theme.WhiteAlpha60
@@ -57,14 +57,15 @@ fun NewsScreen(
             uiState.volumes.forEach { volume ->
                 Button(
                     onClick = { onOpenVolume(volume.id) },
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RectangleShape,
-                    colors = ButtonDefaults.buttonColors(containerColor = White),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(spacing.homeButtonMinHeight),
+                    colors = ButtonDefaults.buttonColors(containerColor = Crimson),
                 ) {
                     Text(
                         text = stringResource(R.string.newsletter_volume, volume.id),
-                        style = MaterialTheme.typography.labelLarge,
-                        color = Navy,
+                        style = MaterialTheme.typography.headlineMedium,
+                        color = White,
                     )
                 }
             }


### PR DESCRIPTION
## Changes

**Countdown box (HomeScreen)**
- Background changed from `NavyLight` to `Crimson`
- All text (title, numbers, unit labels) changed to `White` — readable on the red background

**Newsletter volume buttons (NewsScreen)**
- Match `TicketsScreen` `TicketButton` style: `Crimson` background, `White` `headlineMedium` text, `homeButtonMinHeight` height
- Removed old `RectangleShape` / white-on-navy style

**Band detail header (BandDetailScreen)**
- When no band photo exists and the festival logo fallback is shown, header height is reduced to 45 % of `bandImageHeight` (≈117 dp instead of 260 dp)
- Band name and details are positioned higher, eliminating the large empty gap