### PR TITLE
fix(home): restore pill/oval shape on nav and social buttons (batch-11)

### DIFF
--- a/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
+++ b/PD2026_app/feature/feature-home/src/main/kotlin/sk/punkacidetom/pd2026/feature/home/HomeScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -218,7 +217,6 @@ private fun HomeNavButton(
     Button(
         onClick = onClick,
         modifier = modifier.height(spacing.homeButtonMinHeight),
-        shape = RectangleShape,
         colors = ButtonDefaults.buttonColors(containerColor = White),
     ) {
         FaIcon(name = icon, size = spacing.iconMd, tint = Crimson, modifier = Modifier.padding(end = 6.dp))
@@ -237,7 +235,6 @@ private fun SocialButton(
     Button(
         onClick = onClick,
         modifier = modifier.height(spacing.homeButtonMinHeight),
-        shape = RectangleShape,
         colors = ButtonDefaults.buttonColors(containerColor = White),
     ) {
         FaIcon(


### PR DESCRIPTION
## Summary
- Removed `shape = RectangleShape` from `HomeNavButton` and `SocialButton` in `HomeScreen.kt`
- Buttons now use Material3's default pill/oval shape, consistent with the rest of the app
- Removed the now-unused `import androidx.compose.ui.graphics.RectangleShape`

## Test plan
- [ ] Open the Home screen — all nav buttons (Timetable, Bands, Newsletter, Info, Tickets) should have rounded/pill shape
- [ ] Social buttons (Facebook, Instagram) should also have rounded/pill shape
- [ ] Colors, icons, text, and heights are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)